### PR TITLE
#4 Added: capture fatal error

### DIFF
--- a/configs/config.php
+++ b/configs/config.php
@@ -63,4 +63,7 @@ return [
 
 	// use social login
 	'use_social_login'          => false,
+
+	// capture shutdown error
+	'capture_shutdown_error'    => defined( 'WP_DEBUG' ) && WP_DEBUG,
 ];

--- a/src/technote.php
+++ b/src/technote.php
@@ -285,6 +285,12 @@ class Technote {
 		$this->plugin_data = get_plugin_data( $this->plugin_file, false, false );
 
 		spl_autoload_register( [ $this, 'load_class' ] );
+
+		if ( $this->get_config( 'config', 'capture_shutdown_error' ) ) {
+			add_action( 'shutdown', function () {
+				$this->shutdown();
+			}, 0 );
+		}
 		$this->load_functions();
 	}
 
@@ -411,6 +417,17 @@ class Technote {
 			$this->setting->remove_setting( 'save___log_term' );
 			$this->setting->remove_setting( 'delete___log_interval' );
 		}
+	}
+
+	/**
+	 * shutdown
+	 */
+	private function shutdown() {
+		$error = error_get_last();
+		if ( $error === null ) {
+			return;
+		}
+		$this->log( $error['message'], $error );
 	}
 
 	/**


### PR DESCRIPTION
# 概要
#4 

# 変更内容
* 制御用フラグを追加
  * デバッグ用なのでデバッグ時(WP_DEBUG = true)の時にデフォルトでON
* WordPressのshutdownアクション(@since 1.2.0)をフックしてログに追加

# 影響範囲
既存の機能への影響なし

# 動作要件

# 補足